### PR TITLE
Fix webhook app argument naming

### DIFF
--- a/main.py
+++ b/main.py
@@ -611,7 +611,7 @@ def main() -> None:
             on_shutdown=on_shutdown,
             host=WEBAPP_HOST,
             port=WEBAPP_PORT,
-            app=app,
+            web_app=app,
         )
     else:
         logging.info("Запуск в polling режиме (для разработки)")


### PR DESCRIPTION
## Summary
- use the proper `web_app` keyword when starting the webhook so aiohttp receives a single app argument

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e51f414acc8320a19d37df0674e6b5