### PR TITLE
Fix Google Sheets update ranges

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -226,14 +226,14 @@ def _update_request_status_sync(
     status_cell = f"{_column_letter(REQUESTS_COLUMNS['status'])}{cell.row}"
     updates.append(
         {
-            "range": f"{REQUESTS_SHEET}!{status_cell}:{status_cell}",
+            "range": f"{status_cell}:{status_cell}",
             "values": [[status]],
         }
     )
     updated_at_cell = f"{_column_letter(REQUESTS_COLUMNS['updated_at'])}{cell.row}"
     updates.append(
         {
-            "range": f"{REQUESTS_SHEET}!{updated_at_cell}:{updated_at_cell}",
+            "range": f"{updated_at_cell}:{updated_at_cell}",
             "values": [[datetime.now(timezone.utc).isoformat()]],
         }
     )
@@ -241,7 +241,7 @@ def _update_request_status_sync(
         channel_cell = f"{_column_letter(REQUESTS_COLUMNS['channel_message_id'])}{cell.row}"
         updates.append(
             {
-                "range": f"{REQUESTS_SHEET}!{channel_cell}:{channel_cell}",
+                "range": f"{channel_cell}:{channel_cell}",
                 "values": [[str(channel_message_id)]],
             }
         )


### PR DESCRIPTION
## Summary
- remove duplicated worksheet titles from batch update ranges when updating requests
- prevent Google Sheets API errors caused by malformed A1 ranges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e60f344d208320a97a76678c5e3ede