### PR TITLE
Remove daily request limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Python 3.11 с хранением данных в Google Sheets.
 | `TECH_CHAT_ID` | ID тех. чата для уведомлений об ошибках |
 | `ADMINS` | Список ID директоров через запятую |
 | `TIMEZONE` | Часовой пояс для валидации дат (например, `Europe/Moscow`) |
-| `RATE_LIMIT_PER_DAY` | Лимит заявок на пользователя в сутки |
 | `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` | Base64 JSON сервисного аккаунта Google |
 | `GOOGLE_SPREADSHEET_ID` | ID таблицы Google Sheets |
 


### PR DESCRIPTION
## Summary
- remove rate limit checks when publishing requests
- delete the related storage helpers and environment variable documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6185778308320b9b57cf2250a16aa