### PR TITLE
Handle missing user lookup results in storage

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -341,6 +341,8 @@ def _get_user_sync(user_id: int) -> Optional[Dict[str, Any]]:
         cell = _users_ws.find(str(user_id))
     except gspread.exceptions.CellNotFound:
         return None
+    if cell is None:
+        return None
     row_values = _users_ws.row_values(cell.row)
     data: Dict[str, Any] = {}
     for index, header in enumerate(USERS_HEADERS):


### PR DESCRIPTION
## Summary
- avoid accessing worksheet row when user lookup returns no cell
- keep compatibility with older gspread versions by preserving CellNotFound handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e622f16e08832092f2f6d4ac99344a