### PR TITLE
Fix contacts in invite notifications

### DIFF
--- a/main.py
+++ b/main.py
@@ -266,10 +266,10 @@ async def on_callback_pick(call: CallbackQuery) -> None:
             new_status = "picked"
             message_for_author = (
                 "✅ Директор пригласил вас на смену!\n"
-                f"Свяжитесь с директором: {author_contact}"
+                f"Свяжитесь с директором: {picker_contact}"
             )
             message_for_picker = (
-                f"Контакт: {picker_contact}"
+                f"Контакт: {author_contact}"
             )
 
         channel_message_id = call.message.message_id if call.message else None


### PR DESCRIPTION
## Summary
- send the director's contact information to the worker when they are invited to a shift
- send the worker's contact information to the director after inviting them

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e640f7472c83208872e4c47be12690