### PR TITLE
Normalize request status validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -237,7 +237,8 @@ async def on_callback_pick(call: CallbackQuery) -> None:
             await call.answer("Заявка не найдена или была удалена.", show_alert=True)
             return
 
-        if str(record.get("status")) != "open":
+        status = str(record.get("status") or "").strip().lower()
+        if status != "open":
             await call.answer("Карточка уже закрыта.", show_alert=True)
             return
 


### PR DESCRIPTION
## Summary
- normalize the stored request status before evaluating whether a card is open
- ensure invite buttons remain active despite whitespace or casing discrepancies in Google Sheets data

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e656cb45d08320a057560ab93bdc7c