### PR TITLE
Improve date entry UX and validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 import logging
 import os
-from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+import re
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, Optional, Tuple
 
 from aiohttp import web
 from aiogram import Bot, Dispatcher, types
@@ -25,6 +26,7 @@ BOT_TOKEN = os.getenv("BOT_TOKEN")
 CHANNEL_ID = int(os.getenv("CHANNEL_ID", "0"))
 TECH_CHAT_ID = int(os.getenv("TECH_CHAT_ID", "0"))
 TIMEZONE = ZoneInfo(os.getenv("TIMEZONE", "Europe/Moscow"))
+DATE_WINDOW_DAYS = max(0, int(os.getenv("DATE_WINDOW_DAYS", "90")))
 ADMINS = {
     int(user_id)
     for user_id in os.getenv("ADMINS", "").split(",")
@@ -52,22 +54,396 @@ dp = Dispatcher(bot, storage=fsm_storage)
 
 class DirectorStates(StatesGroup):
     date = State()
-    time_from = State()
-    time_to = State()
+    time_range = State()
+    shop = State()
     note = State()
     confirm = State()
 
 
 class WorkerStates(StatesGroup):
     date = State()
-    time_from = State()
-    time_to = State()
+    time_range = State()
+    shop = State()
     note = State()
     confirm = State()
 
 
 class RegistrationStates(StatesGroup):
     waiting_contact = State()
+
+
+DATE_PLACEHOLDER = "например: 09.10 или “завтра”"
+DATE_PROMPT_MESSAGE = "Выбери дату или введи вручную: 09.10, “завтра”, “суббота”."
+DATE_PARSE_ERROR_MESSAGE = "Не понял дату. Введи как 09.10 или нажми кнопку ниже."
+DATE_CONFIRMATION_TEMPLATE = "Дата: {date_human} (ISO: {date_iso})"
+DATE_BUTTON_TODAY = "Сегодня"
+DATE_BUTTON_TOMORROW = "Завтра"
+DATE_BUTTON_PICK = "Выбрать день"
+BACK_COMMAND = "Назад"
+TIME_PROMPT_MESSAGE = "Укажи время смены в формате 09:00–18:00. Шаг — 15 минут."
+TIME_PLACEHOLDER = "например: 09:00–18:00"
+INLINE_DATE_DAYS = 10
+
+WEEKDAY_SHORT_LABELS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"]
+WEEKDAY_FULL_NAMES = [
+    "Понедельник",
+    "Вторник",
+    "Среда",
+    "Четверг",
+    "Пятница",
+    "Суббота",
+    "Воскресенье",
+]
+MONTH_GENITIVE = {
+    1: "января",
+    2: "февраля",
+    3: "марта",
+    4: "апреля",
+    5: "мая",
+    6: "июня",
+    7: "июля",
+    8: "августа",
+    9: "сентября",
+    10: "октября",
+    11: "ноября",
+    12: "декабря",
+}
+
+NATURAL_DAY_OFFSETS = {
+    "сегодня": 0,
+    "segodnya": 0,
+    "завтра": 1,
+    "zavtra": 1,
+    "послезавтра": 2,
+    "poslezavtra": 2,
+}
+
+WEEKDAY_ALIASES = {
+    "пн": 0,
+    "пон": 0,
+    "понедельник": 0,
+    "вт": 1,
+    "вторник": 1,
+    "ср": 2,
+    "среда": 2,
+    "чт": 3,
+    "четверг": 3,
+    "пт": 4,
+    "пятница": 4,
+    "сб": 5,
+    "суб": 5,
+    "суббота": 5,
+    "вс": 6,
+    "воск": 6,
+    "воскресенье": 6,
+}
+
+
+def build_date_reply_keyboard() -> ReplyKeyboardMarkup:
+    keyboard = ReplyKeyboardMarkup(
+        resize_keyboard=True,
+        input_field_placeholder=DATE_PLACEHOLDER,
+    )
+    keyboard.row(DATE_BUTTON_TODAY, DATE_BUTTON_TOMORROW)
+    keyboard.add(DATE_BUTTON_PICK)
+    return keyboard
+
+
+def build_back_keyboard() -> ReplyKeyboardMarkup:
+    keyboard = ReplyKeyboardMarkup(
+        resize_keyboard=True,
+        one_time_keyboard=False,
+        input_field_placeholder=TIME_PLACEHOLDER,
+    )
+    keyboard.add(BACK_COMMAND)
+    return keyboard
+
+
+def build_inline_date_keyboard(base_date: date) -> InlineKeyboardMarkup:
+    markup = InlineKeyboardMarkup(row_width=3)
+    for offset in range(INLINE_DATE_DAYS):
+        candidate = base_date + timedelta(days=offset)
+        if candidate > base_date + timedelta(days=DATE_WINDOW_DAYS):
+            break
+        label = f"{WEEKDAY_SHORT_LABELS[candidate.weekday()]} {candidate.day:02d}"
+        markup.insert(
+            InlineKeyboardButton(
+                label,
+                callback_data=f"pick_date:{candidate.isoformat()}",
+            )
+        )
+    return markup
+
+
+def format_human_date(value: date) -> str:
+    weekday_name = WEEKDAY_FULL_NAMES[value.weekday()]
+    month_name = MONTH_GENITIVE[value.month]
+    return f"{weekday_name}, {value.day:02d} {month_name} {value.year}"
+
+
+def _normalize_text(value: str) -> str:
+    text = value.strip().lower()
+    text = text.replace("\u2013", "-")
+    text = text.replace("\u2014", "-")
+    text = text.replace("\u2012", "-")
+    text = text.replace("\u2010", "-")
+    text = text.replace(",", ".")
+    text = text.replace("\xa0", " ")
+    text = text.replace("ё", "е")
+    text = text.replace("“", "")
+    text = text.replace("”", "")
+    text = text.replace('"', "")
+    text = text.replace("'", "")
+    text = re.sub(r"\s+", "", text)
+    return text
+
+
+def parse_user_date_input(raw_value: str, *, today: date, max_days: int) -> date:
+    if not raw_value:
+        raise ValueError("empty")
+    normalized = _normalize_text(raw_value)
+    if not normalized:
+        raise ValueError("empty")
+
+    try:
+        candidate = date.fromisoformat(normalized)
+    except ValueError:
+        candidate = None
+
+    if candidate is None:
+        if normalized in NATURAL_DAY_OFFSETS:
+            candidate = today + timedelta(days=NATURAL_DAY_OFFSETS[normalized])
+        elif normalized in WEEKDAY_ALIASES:
+            target_weekday = WEEKDAY_ALIASES[normalized]
+            days_ahead = (target_weekday - today.weekday()) % 7
+            if days_ahead == 0:
+                days_ahead = 7
+            candidate = today + timedelta(days=days_ahead)
+        else:
+            parts = tuple(normalized.split(".")) if "." in normalized else ()
+            candidate = _parse_numeric_date(parts, today)
+
+    if candidate is None:
+        raise ValueError("unparsed")
+
+    if candidate < today:
+        raise ValueError("past")
+
+    if candidate > today + timedelta(days=max_days):
+        raise ValueError("too_far")
+
+    return candidate
+
+
+def _parse_numeric_date(parts: Tuple[str, ...], today: date) -> Optional[date]:
+    if not parts:
+        return None
+    if len(parts) == 2 and all(part.isdigit() for part in parts):
+        day = int(parts[0])
+        month = int(parts[1])
+        try:
+            candidate = date(today.year, month, day)
+        except ValueError:
+            return None
+        if candidate < today:
+            try:
+                candidate = date(today.year + 1, month, day)
+            except ValueError:
+                return None
+        return candidate
+    if (
+        len(parts) == 3
+        and all(part.isdigit() for part in parts)
+        and len(parts[2]) in (2, 4)
+    ):
+        day = int(parts[0])
+        month = int(parts[1])
+        year = int(parts[2])
+        if year < 100:
+            year += 2000 if year < 70 else 1900
+        try:
+            return date(year, month, day)
+        except ValueError:
+            return None
+    return None
+
+
+TIME_RANGE_PATTERN = re.compile(
+    r"^(\d{1,2})(?::?(\d{0,2}))?-(\d{1,2})(?::?(\d{0,2}))?$"
+)
+
+
+def parse_time_range(raw_value: str) -> Optional[Tuple[str, str]]:
+    if not raw_value:
+        return None
+    normalized = raw_value.strip().lower()
+    normalized = normalized.replace(" ", "")
+    normalized = normalized.replace("—", "-")
+    normalized = normalized.replace("–", "-")
+    normalized = normalized.replace("−", "-")
+    normalized = normalized.replace("..", ".")
+    normalized = normalized.replace(",", ":")
+    normalized = normalized.replace(".", ":")
+    match = TIME_RANGE_PATTERN.match(normalized)
+    if not match:
+        return None
+    start_hour, start_minute, end_hour, end_minute = match.groups()
+    start = _normalize_time_component(start_hour, start_minute)
+    end = _normalize_time_component(end_hour, end_minute)
+    if not start or not end:
+        return None
+    return start, end
+
+
+def _normalize_time_component(hour_text: str, minute_text: Optional[str]) -> Optional[str]:
+    hour = int(hour_text)
+    if not 0 <= hour <= 23:
+        return None
+    if minute_text:
+        if len(minute_text) == 1:
+            minute = int(minute_text) * 10
+        else:
+            minute = int(minute_text)
+    else:
+        minute = 0
+    if not 0 <= minute < 60:
+        return None
+    return f"{hour:02d}:{minute:02d}"
+
+
+def resolve_flow(state_name: Optional[str]) -> Optional[str]:
+    if not state_name:
+        return None
+    if state_name.startswith(f"{DirectorStates.__name__}:"):
+        return "director"
+    if state_name.startswith(f"{WorkerStates.__name__}:"):
+        return "worker"
+    return None
+
+
+async def start_date_step(message: types.Message, state: FSMContext, flow: str) -> None:
+    state_cls = DirectorStates if flow == "director" else WorkerStates
+    await state.set_state(state_cls.date.state)
+    await state.set_data({})
+    await message.answer(
+        DATE_PROMPT_MESSAGE,
+        reply_markup=build_date_reply_keyboard(),
+    )
+
+
+async def send_inline_date_choices(message: types.Message) -> None:
+    today_local = datetime.now(TIMEZONE).date()
+    markup = build_inline_date_keyboard(today_local)
+    if not markup.inline_keyboard:
+        await message.answer("Нет доступных дат в заданном окне.")
+        return
+    await message.answer("Выберите дату из списка ниже:", reply_markup=markup)
+
+
+async def prompt_time_range(message: types.Message, state: FSMContext, flow: str) -> None:
+    state_cls = DirectorStates if flow == "director" else WorkerStates
+    await state.set_state(state_cls.time_range.state)
+    await message.answer(TIME_PROMPT_MESSAGE, reply_markup=build_back_keyboard())
+
+
+async def apply_date_selection(
+    message: types.Message, state: FSMContext, flow: str, selected_date: date
+) -> None:
+    date_iso = selected_date.isoformat()
+    date_human = format_human_date(selected_date)
+    await state.update_data(date=date_iso, date_human=date_human)
+    await message.answer(
+        DATE_CONFIRMATION_TEMPLATE.format(date_human=date_human, date_iso=date_iso),
+        reply_markup=ReplyKeyboardRemove(),
+    )
+    await prompt_time_range(message, state, flow)
+
+
+async def process_date_message(message: types.Message, state: FSMContext) -> None:
+    state_name = await state.get_state()
+    flow = resolve_flow(state_name)
+    if not flow:
+        logging.error(
+            "Не удалось определить поток для обработки даты. state=%s user=%s",
+            state_name,
+            message.from_user.id if message.from_user else "unknown",
+        )
+        return
+    today_local = datetime.now(TIMEZONE).date()
+    try:
+        parsed_date = parse_user_date_input(
+            message.text or "",
+            today=today_local,
+            max_days=DATE_WINDOW_DAYS,
+        )
+    except ValueError as exc:
+        logging.info(
+            "Не удалось распознать дату '%s' от пользователя %s: %s",
+            message.text,
+            message.from_user.id if message.from_user else "unknown",
+            exc,
+        )
+        await message.answer(DATE_PARSE_ERROR_MESSAGE)
+        await message.answer(
+            DATE_PROMPT_MESSAGE,
+            reply_markup=build_date_reply_keyboard(),
+        )
+        return
+    await apply_date_selection(message, state, flow, parsed_date)
+
+
+async def process_date_callback(call: CallbackQuery, state: FSMContext, iso_value: str) -> None:
+    state_name = await state.get_state()
+    flow = resolve_flow(state_name)
+    if not flow:
+        logging.error(
+            "Не удалось определить поток для callback-даты. state=%s user=%s",
+            state_name,
+            call.from_user.id if call.from_user else "unknown",
+        )
+        await call.answer("Ошибка состояния", show_alert=True)
+        return
+    today_local = datetime.now(TIMEZONE).date()
+    try:
+        parsed_date = parse_user_date_input(
+            iso_value,
+            today=today_local,
+            max_days=DATE_WINDOW_DAYS,
+        )
+    except ValueError as exc:
+        logging.info(
+            "Не удалось распознать дату '%s' из callback от пользователя %s: %s",
+            iso_value,
+            call.from_user.id if call.from_user else "unknown",
+            exc,
+        )
+        await call.answer(DATE_PARSE_ERROR_MESSAGE, show_alert=True)
+        return
+    await call.answer()
+    try:
+        await call.message.edit_reply_markup()
+    except Exception:  # noqa: BLE001
+        logging.debug("Не удалось скрыть inline-клавиатуру после выбора даты")
+    await apply_date_selection(call.message, state, flow, parsed_date)
+
+
+async def handle_back_to_date(message: types.Message, state: FSMContext) -> None:
+    state_name = await state.get_state()
+    flow = resolve_flow(state_name)
+    if not flow:
+        await message.answer("Возвращаюсь в начало меню.")
+        await start_menu(message)
+        return
+    await start_date_step(message, state, flow)
+
+
+async def on_pick_date_selection(call: CallbackQuery, state: FSMContext) -> None:
+    try:
+        _, iso_value = call.data.split(":", 1)
+    except (AttributeError, ValueError):
+        await call.answer("Некорректная дата", show_alert=True)
+        return
+    await process_date_callback(call, state, iso_value)
 
 
 async def ensure_user(ctx: types.User, phone_number: Optional[str] = None) -> str:
@@ -374,33 +750,45 @@ def run_director_flow(dispatcher: Dispatcher) -> None:
         if not await ensure_contact_exists(message):
             return
         await state.finish()
-        await message.answer(
-            "Укажите дату смены в формате ГГГГ-ММ-ДД:",
-            reply_markup=ReplyKeyboardRemove(),
-        )
-        await DirectorStates.date.set()
+        await start_date_step(message, state, "director")
+
+    @dispatcher.message_handler(
+        lambda m: (m.text or "").strip().lower() == DATE_BUTTON_PICK.lower(),
+        state=DirectorStates.date,
+    )
+    async def director_date_inline_prompt(message: types.Message, _: FSMContext) -> None:
+        await send_inline_date_choices(message)
 
     @dispatcher.message_handler(state=DirectorStates.date)
     async def director_date(message: types.Message, state: FSMContext) -> None:
-        await state.update_data(date=message.text.strip())
-        await message.answer("Укажите время начала смены (ЧЧ:ММ):")
-        await DirectorStates.next()
+        await process_date_message(message, state)
 
-    @dispatcher.message_handler(state=DirectorStates.time_from)
-    async def director_time_from(message: types.Message, state: FSMContext) -> None:
-        await state.update_data(time_from=message.text.strip())
-        await message.answer("Укажите время окончания смены (ЧЧ:ММ):")
-        await DirectorStates.next()
-
-    @dispatcher.message_handler(state=DirectorStates.time_to)
-    async def director_time_to(message: types.Message, state: FSMContext) -> None:
-        await state.update_data(time_to=message.text.strip())
-        data = await state.get_data()
-        error = validate_timeslot(data.get("date", ""), data.get("time_from", ""), data.get("time_to", ""))
-        if error:
-            await message.answer(error + " Попробуйте снова. Укажите дату в формате ГГГГ-ММ-ДД.")
-            await DirectorStates.date.set()
+    @dispatcher.message_handler(state=DirectorStates.time_range)
+    async def director_time_range(message: types.Message, state: FSMContext) -> None:
+        if (message.text or "").strip().lower() == BACK_COMMAND.lower():
+            await handle_back_to_date(message, state)
             return
+        parsed_range = parse_time_range(message.text or "")
+        if not parsed_range:
+            await message.answer(
+                "Не понял время. " + TIME_PROMPT_MESSAGE,
+                reply_markup=build_back_keyboard(),
+            )
+            return
+        time_from, time_to = parsed_range
+        data = await state.get_data()
+        error = validate_timeslot(
+            data.get("date", ""),
+            time_from,
+            time_to,
+        )
+        if error:
+            await message.answer(
+                f"{error} {TIME_PROMPT_MESSAGE}",
+                reply_markup=build_back_keyboard(),
+            )
+            return
+        await state.update_data(time_from=time_from, time_to=time_to)
         shops = await fetch_shops()
         if not shops:
             await message.answer(
@@ -414,9 +802,12 @@ def run_director_flow(dispatcher: Dispatcher) -> None:
             keyboard.insert(
                 InlineKeyboardButton(shop_name, callback_data=f"director_shop:{shop_id}")
             )
+        await state.set_state(DirectorStates.shop.state)
         await message.answer("Выберите вашу лавку:", reply_markup=keyboard)
 
-    @dispatcher.callback_query_handler(lambda c: c.data.startswith("director_shop:"), state=DirectorStates.time_to)
+    @dispatcher.callback_query_handler(
+        lambda c: c.data.startswith("director_shop:"), state=DirectorStates.shop
+    )
     async def director_shop_choice(call: CallbackQuery, state: FSMContext) -> None:
         shop_id = int(call.data.split(":", 1)[1])
         shops = await fetch_shops()
@@ -426,10 +817,13 @@ def run_director_flow(dispatcher: Dispatcher) -> None:
         await call.answer()
         await state.update_data(shop_id=shop_id, shop_name=shops[shop_id])
         await call.message.edit_text("Добавьте комментарий (можно телефон). Если не нужно, напишите «Без комментариев».")
-        await DirectorStates.next()
+        await DirectorStates.note.set()
 
     @dispatcher.message_handler(state=DirectorStates.note)
     async def director_note(message: types.Message, state: FSMContext) -> None:
+        if (message.text or "").strip().lower() == BACK_COMMAND.lower():
+            await handle_back_to_date(message, state)
+            return
         await state.update_data(note=message.text.strip())
         data = await state.get_data()
         shops = await fetch_shops()
@@ -467,41 +861,56 @@ def run_worker_flow(dispatcher: Dispatcher) -> None:
         if not await ensure_contact_exists(message):
             return
         await state.finish()
-        await message.answer(
-            "Укажите дату, когда готовы выйти, в формате ГГГГ-ММ-ДД:",
-            reply_markup=ReplyKeyboardRemove(),
-        )
-        await WorkerStates.date.set()
+        await start_date_step(message, state, "worker")
+
+    @dispatcher.message_handler(
+        lambda m: (m.text or "").strip().lower() == DATE_BUTTON_PICK.lower(),
+        state=WorkerStates.date,
+    )
+    async def worker_date_inline_prompt(message: types.Message, _: FSMContext) -> None:
+        await send_inline_date_choices(message)
 
     @dispatcher.message_handler(state=WorkerStates.date)
     async def worker_date(message: types.Message, state: FSMContext) -> None:
-        await state.update_data(date=message.text.strip())
-        await message.answer("Укажите время начала смены (ЧЧ:ММ):")
-        await WorkerStates.next()
+        await process_date_message(message, state)
 
-    @dispatcher.message_handler(state=WorkerStates.time_from)
-    async def worker_time_from(message: types.Message, state: FSMContext) -> None:
-        await state.update_data(time_from=message.text.strip())
-        await message.answer("Укажите время окончания смены (ЧЧ:ММ):")
-        await WorkerStates.next()
-
-    @dispatcher.message_handler(state=WorkerStates.time_to)
-    async def worker_time_to(message: types.Message, state: FSMContext) -> None:
-        await state.update_data(time_to=message.text.strip())
-        data = await state.get_data()
-        error = validate_timeslot(data.get("date", ""), data.get("time_from", ""), data.get("time_to", ""))
-        if error:
-            await message.answer(error + " Попробуйте снова. Укажите дату в формате ГГГГ-ММ-ДД.")
-            await WorkerStates.date.set()
+    @dispatcher.message_handler(state=WorkerStates.time_range)
+    async def worker_time_range(message: types.Message, state: FSMContext) -> None:
+        if (message.text or "").strip().lower() == BACK_COMMAND.lower():
+            await handle_back_to_date(message, state)
             return
+        parsed_range = parse_time_range(message.text or "")
+        if not parsed_range:
+            await message.answer(
+                "Не понял время. " + TIME_PROMPT_MESSAGE,
+                reply_markup=build_back_keyboard(),
+            )
+            return
+        time_from, time_to = parsed_range
+        data = await state.get_data()
+        error = validate_timeslot(
+            data.get("date", ""),
+            time_from,
+            time_to,
+        )
+        if error:
+            await message.answer(
+                f"{error} {TIME_PROMPT_MESSAGE}",
+                reply_markup=build_back_keyboard(),
+            )
+            return
+        await state.update_data(time_from=time_from, time_to=time_to)
         shops = await fetch_shops()
         keyboard = InlineKeyboardMarkup(row_width=2)
         for shop_id, shop_name in shops.items():
             keyboard.insert(InlineKeyboardButton(shop_name, callback_data=f"worker_shop:{shop_id}"))
         keyboard.add(InlineKeyboardButton("Любая лавка", callback_data="worker_shop:any"))
+        await state.set_state(WorkerStates.shop.state)
         await message.answer("Выберите лавку, в которой вы работаете:", reply_markup=keyboard)
 
-    @dispatcher.callback_query_handler(lambda c: c.data.startswith("worker_shop:"), state=WorkerStates.time_to)
+    @dispatcher.callback_query_handler(
+        lambda c: c.data.startswith("worker_shop:"), state=WorkerStates.shop
+    )
     async def worker_shop_choice(call: CallbackQuery, state: FSMContext) -> None:
         _, raw_id = call.data.split(":", 1)
         if raw_id == "any":
@@ -520,10 +929,13 @@ def run_worker_flow(dispatcher: Dispatcher) -> None:
             await call.answer()
             await state.update_data(shop_id=shop_id, shop_name=shops[shop_id])
         await call.message.edit_text("Расскажите, на какую роль готовы выйти и оставьте комментарий.")
-        await WorkerStates.next()
+        await WorkerStates.note.set()
 
     @dispatcher.message_handler(state=WorkerStates.note)
     async def worker_note(message: types.Message, state: FSMContext) -> None:
+        if (message.text or "").strip().lower() == BACK_COMMAND.lower():
+            await handle_back_to_date(message, state)
+            return
         await state.update_data(note=message.text.strip())
         data = await state.get_data()
         shops = await fetch_shops()
@@ -615,6 +1027,25 @@ async def on_shutdown(_: Dispatcher) -> None:
 def register_handlers() -> None:
     run_director_flow(dp)
     run_worker_flow(dp)
+    dp.register_callback_query_handler(
+        on_pick_date_selection,
+        lambda c: c.data and c.data.startswith("pick_date:"),
+        state=[DirectorStates.date, WorkerStates.date],
+    )
+    dp.register_message_handler(
+        handle_back_to_date,
+        lambda m: (m.text or "").strip().lower() == BACK_COMMAND.lower(),
+        state=[
+            DirectorStates.time_range,
+            DirectorStates.shop,
+            DirectorStates.note,
+            DirectorStates.confirm,
+            WorkerStates.time_range,
+            WorkerStates.shop,
+            WorkerStates.note,
+            WorkerStates.confirm,
+        ],
+    )
     dp.register_callback_query_handler(on_callback_pick, lambda c: c.data and c.data.startswith("pick:"))
 
 


### PR DESCRIPTION
## Summary
- add reusable human-friendly date parsing with quick reply buttons, inline calendar and validation window
- update director and worker FSM flows to use the new date step, unified time range input and back navigation
- normalize time range parsing, log parse issues and keep ISO storage for Google Sheets

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e6625ede7c8320893c6be6a1d1da8f