### PR TITLE
Show inline date picker when starting date step

### DIFF
--- a/main.py
+++ b/main.py
@@ -329,6 +329,7 @@ async def start_date_step(message: types.Message, state: FSMContext, flow: str) 
         DATE_PROMPT_MESSAGE,
         reply_markup=build_date_reply_keyboard(),
     )
+    await send_inline_date_choices(message)
 
 
 async def send_inline_date_choices(message: types.Message) -> None:


### PR DESCRIPTION
## Summary
- automatically send the inline date picker after prompting the user for a date so the options are always visible

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e6669049e48320a4c3a4224447bc37