### PR TITLE
Reset bot state when handling /start command

### DIFF
--- a/main.py
+++ b/main.py
@@ -968,11 +968,12 @@ def run_worker_flow(dispatcher: Dispatcher) -> None:
         await handle_post_publication(call.message.chat.id, call.from_user, state, "worker")
 
 
-@dp.message_handler(commands=["start"])
+@dp.message_handler(commands=["start"], state="*")
 async def cmd_start(message: types.Message, state: FSMContext) -> None:
+    # Сбрасываем любые активные состояния, чтобы полностью перезапустить сценарий.
+    await state.finish()
     if not await ensure_contact_exists(message):
         return
-    await state.finish()
     await start_menu(message)
 
 


### PR DESCRIPTION
## Summary
- handle the /start command in any FSM state to ensure flows are reset
- finish any active state before showing the main menu again

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e66afde510832092965143eafe7f19