### PR TITLE
Return to main menu after cancelling a request

### DIFF
--- a/main.py
+++ b/main.py
@@ -848,6 +848,7 @@ def run_director_flow(dispatcher: Dispatcher) -> None:
         await call.answer("Заявка отменена")
         await state.finish()
         await call.message.edit_text("Заявка отменена. Возвращайтесь, когда будете готовы.")
+        await start_menu(call.message)
 
     @dispatcher.callback_query_handler(lambda c: c.data == "director_confirm", state=DirectorStates.confirm)
     async def director_confirm(call: CallbackQuery, state: FSMContext) -> None:
@@ -960,6 +961,7 @@ def run_worker_flow(dispatcher: Dispatcher) -> None:
         await call.answer("Заявка отменена")
         await state.finish()
         await call.message.edit_text("Заявка отменена. Возвращайтесь, когда будете готовы.")
+        await start_menu(call.message)
 
     @dispatcher.callback_query_handler(lambda c: c.data == "worker_confirm", state=WorkerStates.confirm)
     async def worker_confirm(call: CallbackQuery, state: FSMContext) -> None:


### PR DESCRIPTION
## Summary
- send users back to the start menu after cancelling director or worker requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67575ae98832089a2b8eab231f6e8