### PR TITLE
Handle "Pick day" button in date input

### DIFF
--- a/main.py
+++ b/main.py
@@ -371,6 +371,10 @@ async def process_date_message(message: types.Message, state: FSMContext) -> Non
             message.from_user.id if message.from_user else "unknown",
         )
         return
+    normalized_text = (message.text or "").strip().lower()
+    if normalized_text == DATE_BUTTON_PICK.lower():
+        await send_inline_date_choices(message)
+        return
     today_local = datetime.now(TIMEZONE).date()
     try:
         parsed_date = parse_user_date_input(


### PR DESCRIPTION
## Summary
- treat the "Выбрать день" button as a special case when processing date messages
- resend the inline date keyboard when the button is pressed so the user sees the options

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e67899f2c88320a26580bb12186d9a